### PR TITLE
feat(Readme): add stronger wording to supplying readme information

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This should work happily with the package manager of your choice, though we have
 
 ## 💭 Your thoughts
 
-We find it useful if you can document some of your thinking, including what you would improve given more time.
-known issues and how you would resolve them given more time. Technical decisions, design decisions, compromises.
+Add even more colour to your submission by outlining the considerations you made with this task. What technical/design decisions and compromises did you make and why?
+What would you improve given more time? What are the known issues and how you would resolve them?
 
 Leave them below and push them with your submission 👇


### PR DESCRIPTION
Thinking that we should **expect** README and supplemental information to back up the task, in order to get an insight into the candidates thinking at the task stage.

Did consider a more structured approach (ie, set blank sections for the candidate to fill out), but that might be too clinical